### PR TITLE
Adding stack canary support for safe large stack usages.

### DIFF
--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -20,6 +20,10 @@ static llvm::cl::OptionCategory EosioLdToolCategory("ld options");
 #endif
 
 /// begin ld options
+static cl::opt<bool> stack_canary_opt(
+   "stack-canary",
+   cl::desc("Stack canary for non stack first layouts"),
+   cl::cat(LD_CAT));
 static cl::opt<std::string> abi_version_opt(
     "abi-version",
     cl::desc("Which ABI version to generate"),
@@ -786,6 +790,9 @@ static Options CreateOptions(bool add_defaults=true) {
 #endif
    if (!fnative_opt) {
 #ifdef ONLY_LD
+      if (stack_canary_opt) {
+         ldopts.emplace_back("--stack-canary");
+      }
       if (!fno_stack_first_opt) {
          ldopts.emplace_back("-stack-first");
       }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Currently with CDT, the only way to use a large stack is to use the option `-fno-stack-first`.  This is problematic as it forces the smart contract developer to choose a non-safe option.  To circumvent this, this PR adds support for a new command line option `-stack-canary` which will protect against stack overflow issues from possibly allowing corrupted action runs to succeed.

The current way linear memory is laid out with `-fno-stack-first` is:
[ data section | stack section | heap section ]
By placing a canary value at the border of the stack section and data section and placing the same canary into a WASM global at the beginning of execution we can test these values at the end of execution and assert if they are no longer equal (i.e. the stack overflowed and overwrote part of the data section).

This new assert code is 8000000000000000002 to signify that a canary failure has occurred.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
One new command line option to both cdt-cpp, cdt-cc, and cdt-ld has been added (`-stack-canary`).
One new assert code has been added to compiler owned and generated errors (8000000000000000002).

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
