### PR TITLE
Finish fixing build

### DIFF
--- a/libraries/eosiolib/contracts/eosio/eosio.hpp
+++ b/libraries/eosiolib/contracts/eosio/eosio.hpp
@@ -5,7 +5,6 @@
 #pragma once
 #include "action.hpp"
 #include "../../core/eosio/print.hpp"
-#include "map.hpp"
 #include "multi_index.hpp"
 #include "dispatcher.hpp"
 #include "contract.hpp"

--- a/tests/unit/test_contracts/CMakeLists.txt
+++ b/tests/unit/test_contracts/CMakeLists.txt
@@ -4,7 +4,6 @@ add_contract(malloc_tests old_malloc_tests malloc_tests.cpp)
 add_contract(simple_tests simple_tests simple_tests.cpp)
 add_contract(transfer_contract transfer_contract transfer.cpp)
 add_contract(minimal_tests minimal_tests minimal_tests.cpp)
-add_contract(read_only_query_tests read_only_query_tests read_only_query_tests.cpp)
 add_contract(capi_tests capi_tests capi/capi.c capi/action.c capi/chain.c capi/crypto.c capi/db.c capi/permission.c
                                    capi/print.c capi/privileged.c capi/system.c capi/transaction.c)
 


### PR DESCRIPTION
Remove `read_only_query_tests`
Resolves: https://github.com/eosnetworkfoundation/mandel.cdt/issues/18

Remove `map.hpp`
relates to: https://github.com/eosnetworkfoundation/mandel.cdt/issues/14