### PR TITLE
Reinstate abi_variant variants to abi struct.

### DIFF
--- a/tools/include/eosio/abi.hpp
+++ b/tools/include/eosio/abi.hpp
@@ -70,6 +70,7 @@ struct abi {
    std::set<abi_typedef>                  typedefs;
    std::set<abi_action>                   actions;
    std::set<abi_table>                    tables;
+   std::set<abi_variant>                  variants;
    std::vector<abi_ricardian_clause_pair> ricardian_clauses;
    std::vector<abi_error_message>         error_messages;
    std::set<abi_action_result>            action_results;


### PR DESCRIPTION
Resolves: https://github.com/eosnetworkfoundation/mandel.cdt/issues/16