### PR TITLE
Update includes to remove table.hpp for unit tests to pass.

### DIFF
--- a/tests/toolchain/compile-fail/hf_indirect_call_tests.cpp
+++ b/tests/toolchain/compile-fail/hf_indirect_call_tests.cpp
@@ -1,5 +1,4 @@
 #include <eosio/eosio.hpp>
-#include <eosio/table.hpp>
 #include <eosio/contract.hpp>
 #include <eosio/action.hpp>
 #include <eosio/crypto.hpp>

--- a/tests/toolchain/compile-fail/host_functions_tests.cpp
+++ b/tests/toolchain/compile-fail/host_functions_tests.cpp
@@ -11,7 +11,6 @@ send_deferred : yes
 */
 
 #include <eosio/eosio.hpp>
-#include <eosio/table.hpp>
 #include <eosio/contract.hpp>
 #include <eosio/action.hpp>
 #include <eosio/crypto.hpp>


### PR DESCRIPTION
Resolves: https://github.com/eosnetworkfoundation/mandel.cdt/issues/21