### PR TITLE
Fix building integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ If issues persist with ccache
 export CCACHE_DISABLE=1
 ```
 
+#### For building integration tests with mandel built from source (not installed)
+
+Need to provide some environment variables to find necessary test dependencies
+Currently need both while mandel repo is undergoing evolution in naming.
+
+```sh
+export mandel_DIR=${mandel_root}/build/lib/cmake/eosio
+export eosio_DIR=${mandel_root}/build/lib/cmake/eosio
+```
+
 ### Guided Installation or Building from Scratch
 ```sh
 git clone --recursive https://github.com/eosnetworkfoundation/mandel.cdt

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ Or you can install globally by running this command:
 sudo make install
 ```
 
+### Running Tests
+
+#### Unit Tests
+```sh
+cd build
+
+ctest
+```
+
+#### Running Integration Tests (if built)
+```sh
+cd build/tests/integration
+
+ctest
+```
+
 ### Uninstall after manual installation
 
 ```sh

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -6,6 +6,9 @@ set(EOSIO_VERSION_SOFT_MAX "3.0")
 
 find_package(eosio)
 
+find_path(GMP_INCLUDE_DIR NAMES gmp.h)
+find_library(GMP_LIBRARY gmp)
+
 ### Check the version of eosio
 set(VERSION_MATCH_ERROR_MSG "")
 EOSIO_CHECK_VERSION(VERSION_OUTPUT "${EOSIO_VERSION}"
@@ -31,6 +34,8 @@ include_directories(${CMAKE_BINARY_DIR})
 file(GLOB INT_TESTS "*.cpp" "*.hpp")
 
 add_eosio_test_executable( integration_tests ${INT_TESTS} )
+
+target_link_libraries( integration_tests ${GMP_LIBRARY} )
 
 foreach(TEST_SUITE ${INT_TESTS}) # create an independent target for each test suite
   execute_process(COMMAND bash -c "grep -E 'BOOST_AUTO_TEST_SUITE\\s*[(]' ${TEST_SUITE} | grep -vE '//.*BOOST_AUTO_TEST_SUITE\\s*[(]' | cut -d ')' -f 1 | cut -d '(' -f 2" OUTPUT_VARIABLE SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # get the test suite name from the *.cpp file


### PR DESCRIPTION
Fixing/Documenting what is needed from the mandel.cdt side to fix integration test build/link issues.
Will be paired with commit on mandel side.

Resolves: https://github.com/eosnetworkfoundation/mandel.cdt/issues/23

Related issue in mandel: https://github.com/eosnetworkfoundation/mandel/issues/420
Related to mandel PR: https://github.com/eosnetworkfoundation/mandel/pull/421