### PR TITLE
update docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,18 @@
 # EOSIO.CDT (Contract Development Toolkit)
 
-EOSIO.CDT is a toolchain for WebAssembly (WASM) and set of tools to facilitate smart contract development for the EOSIO platform. In addition to being a general purpose WebAssembly toolchain, [EOSIO](https://github.com/eosio/eos) specific optimizations are available to support building EOSIO smart contracts.  This new toolchain is built around [Clang 7](https://github.com/eosio/llvm), which means that EOSIO.CDT has the most currently available optimizations and analyses from LLVM, but as the WASM target is still considered experimental, some optimizations are incomplete or not available.
-
-## New Introductions
-
-As of this release two new repositories are under the suite of tools provided by **EOSIO.CDT**.  These are the [Ricardian Template Toolkit](https://github.com/eosio/ricardian-template-toolkit) and the [Ricardian Specification](https://github.com/eosio/ricardian-spec). The **Ricardian Template Toolkit** is a set of libraries to facilitate smart contract writers in crafting their Ricardian contracts.  The Ricardian specification is the working specification for the above mentioned toolkit.  Please note that both projects are **alpha** releases and are subject to change.
+EOSIO.CDT is a toolchain for WebAssembly (WASM) and set of tools to facilitate smart contract development for the EOSIO platform. In addition to being a general purpose WebAssembly toolchain, [Mandel](https://github.com/eosnetworkfoundation/mandel) specific optimizations are available to support building EOSIO smart contracts.  This new toolchain is built around [Clang 9](https://github.com/eosnetworkfoundation/cdt-llvm), which means that EOSIO.CDT has the most currently available optimizations and analyses from LLVM, but as the WASM target is still considered experimental, some optimizations are incomplete or not available.
 
 ## Upgrading
 
-There's been a round of braking changes, if you are upgrading from older version please read the [Upgrade guide from 1.2 to 1.3](./04_upgrading/1.2-to-1.3.md) and [Upgrade guide from 1.5 to 1.6](./04_upgrading/1.5-to-1.6.md).
+There's been a round of braking changes, if you are upgrading from an older version please read [Upgrading CDT to Mandel](./04_upgrading/eosio.cdt-to-mandel.cdt.md).
 
 ## Contributing
 
-[Contributing Guide](https://github.com/EOSIO/eosio.cdt/blob/develop/CONTRIBUTING.md)
-
-[Code of Conduct](https://github.com/EOSIO/eosio.cdt/blob/develop/CONTRIBUTING.md#conduct)
+See the [Contributing Guide](https://github.com/eosnetworkfoundation/mandel/blob/main/CONTRIBUTING.md)
 
 ## License
 
-[MIT](https://github.com/EOSIO/eosio.cdt/blob/develop/LICENSE)
+[MIT](./../LICENSE)
 
 ## Important
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
General cleanup of docs index.md and intended to be consistent with main README.md . Updated to eosnetwork Clang9 reference from Clang7, updated to eosnetwork Mandel from previous, removed the references to ricardian repos as they no longer exist, scoped the upgrading to most recent name changes.


## API Changes
None


## Documentation Additions
None
